### PR TITLE
Lifecycle and Timer Management update

### DIFF
--- a/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/components/AnimatedGameScore.kt
+++ b/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/components/AnimatedGameScore.kt
@@ -41,12 +41,12 @@ fun AnimatedGameScore(title: String, value: String) {
     Surface(
         modifier = Modifier
             .padding(all = 8.dp)
+            .scale(animatedScale)
             .border(
                 width = 1.5.dp,
                 color = MaterialTheme.colorScheme.primary,
                 shape = RoundedCornerShape(8.dp)
-            )
-            .scale(animatedScale),
+            ),
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.1f)
     ) {

--- a/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/components/PauseOnBackground.kt
+++ b/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/components/PauseOnBackground.kt
@@ -14,13 +14,15 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
  * @param onPause Callback that will be invoked when the ON_PAUSE lifecycle event occurs
  */
 @Composable
-fun PauseOnBackground(onPause: () -> Unit) {
+fun PauseOnBackground(onPause: () -> Unit, onResume: () -> Unit) {
     val lifecycleOwner = LocalLifecycleOwner.current
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_PAUSE) {
                 onPause()
+            }else if(event == Lifecycle.Event.ON_RESUME) {
+                onResume()
             }
         }
 

--- a/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/components/PauseOnBackground.kt
+++ b/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/components/PauseOnBackground.kt
@@ -21,7 +21,7 @@ fun PauseOnBackground(onPause: () -> Unit, onResume: () -> Unit) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_PAUSE) {
                 onPause()
-            }else if(event == Lifecycle.Event.ON_RESUME) {
+            } else if(event == Lifecycle.Event.ON_RESUME) {
                 onResume()
             }
         }

--- a/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/screens/game/EasyGameScreen.kt
+++ b/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/screens/game/EasyGameScreen.kt
@@ -64,9 +64,11 @@ fun EasyGameScreen(
     var isTimerPaused by remember { mutableStateOf(false) }
 
     // Pause timer when app goes to background
-    PauseOnBackground {
+    PauseOnBackground(onPause = {
         isTimerPaused = true
-    }
+    }, onResume = {
+        isTimerPaused = false
+    })
 
     var mutableColorBoxes by remember {
         mutableStateOf(generateColorPairs(gameState.gridSize))

--- a/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/screens/game/HardGameScreen.kt
+++ b/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/screens/game/HardGameScreen.kt
@@ -60,9 +60,11 @@ fun HardGameScreen(
     var isTimerPaused by remember { mutableStateOf(false) }
 
     // Pause timer when app goes to background
-    PauseOnBackground {
+    PauseOnBackground(onPause = {
         isTimerPaused = true
-    }
+    }, onResume = {
+        isTimerPaused = false
+    })
 
     var mutableColorBoxes by remember {
         mutableStateOf(generateColorPairs(gameState.gridSize))

--- a/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/screens/game/MediumGameScreen.kt
+++ b/app/src/main/java/dev/toufikforyou/colormatching/main/presentation/screens/game/MediumGameScreen.kt
@@ -60,9 +60,11 @@ fun MediumGameScreen(
     var isTimerPaused by remember { mutableStateOf(false) }
 
     // Pause timer when app goes to background
-    PauseOnBackground {
+    PauseOnBackground(onPause = {
         isTimerPaused = true
-    }
+    }, onResume = {
+        isTimerPaused = false
+    })
 
     var mutableColorBoxes by remember {
         mutableStateOf(generateColorPairs(gameState.gridSize))


### PR DESCRIPTION
This pull request improves how the game timer is managed across all difficulty screens and enhances the animation of the game score component. The main changes include updating the pause/resume lifecycle handling to ensure the timer resumes correctly when the app returns to the foreground, and a small refactor to the UI animation code for the score display.

**Lifecycle and Timer Management:**

* Updated the `PauseOnBackground` composable to accept both `onPause` and `onResume` callbacks, allowing screens to handle both pause and resume events from the app lifecycle.
* Modified `EasyGameScreen`, `MediumGameScreen`, and `HardGameScreen` to use the new `PauseOnBackground` API, so the timer pauses when the app goes to the background and resumes when it returns to the foreground. [[1]](diffhunk://#diff-b1b5d1c40754d7adf9012142b44a83fdc163365f04e69cf23f9e53153bcbf778L67-R71) [[2]](diffhunk://#diff-1de32f097a5590c1c06b196c2f26c205d04f766e08a8929953ae21a66d0818b1L63-R67) [[3]](diffhunk://#diff-6d19646f5248b65f26ee9dcb08a5d1fa6711cf3da53de471a316186bc05ceadaL63-R67)

**UI Animation:**

* Refactored the modifier order in `AnimatedGameScore` to ensure the animated scale is applied before the border, improving the visual appearance of the score component.